### PR TITLE
Remove leftover std::cout

### DIFF
--- a/lib/EvalMaxSAT/src/EvalMaxSAT.h
+++ b/lib/EvalMaxSAT/src/EvalMaxSAT.h
@@ -608,7 +608,7 @@ public:
                                     auto curCost = LO.optimize( curSolution, std::min(0.1 * chronoLastOptimize.tacSec(), 60.0) );
 
                                     if(curCost < solutionCost) {
-                                        std::cout << "o " << curCost << std::endl;
+                                        //std::cout << "o " << curCost << std::endl;
                                         solutionCost = curCost;
                                         solution = curSolution;
 


### PR DESCRIPTION
It looks to me that there is a `std::cout` that is not needed, and only clutters the stdout when using EvalMaxSAT as a library. That is what happens to me at least, when using EvalMaxSAT as a library.

I have commented that `std::cout`. Feel free to merge the change, if you believe it makes sense.